### PR TITLE
Stringily dispatcher payload data

### DIFF
--- a/scripts/utils/registerAlt.js
+++ b/scripts/utils/registerAlt.js
@@ -127,7 +127,7 @@ function registerAlt() {
         alt: i,
         id: id,
         action: Symbol.keyFor(payload.action),
-        data: payload.data
+        data: JSON.stringify(payload.data)
       })
 
       snapshots[id] = alt.takeSnapshot()


### PR DESCRIPTION
Fixes issue with #5, where Window.postMessage occasionally throws an error when called by the devtool due to the implementation of the [structured cloning algorithm](https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/The_structured_clone_algorithm). 

Passing the payload data into `JSON.stringify` flattens the objects (functions, `Error`s, and DOM nodes) that cause errors when cloned thus fixing the issue.

See my comment on issue #5 for more details.
